### PR TITLE
fix(404): put <title> in the correct position

### DIFF
--- a/material/404.html
+++ b/material/404.html
@@ -2,7 +2,7 @@
   This file was automatically generated - do not edit
 -#}
 {% set title_override = "<h1>404 Not Found</h1>" %}
+{% extends "main.html" %}
 {% block htmltitle %}
   <title>404 Not Found - {{ config.site_name }}</title>
 {% endblock %}
-{% extends "main.html" %}

--- a/src/404.html
+++ b/src/404.html
@@ -22,8 +22,8 @@
 
 {% set title_override = "<h1>404 Not Found</h1>" %}
 
+{% extends "main.html" %}
+
 {% block htmltitle %}
   <title>404 Not Found - {{ config.site_name }}</title>
 {% endblock %}
-
-{% extends "main.html" %}


### PR DESCRIPTION
The <title> was at the beginning of the HTML file, before <!doctype>.