### PR TITLE
perf: replace gfont and gstatic with loli.net cdn

### DIFF
--- a/docs/setup/ensuring-data-privacy.md
+++ b/docs/setup/ensuring-data-privacy.md
@@ -364,8 +364,8 @@ removed during the build process.
     .
     └─ assets/external/
        ├─ unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
-       ├─ fonts.googleapis.com/css
-       ├─ fonts.gstatic.com/s/
+       ├─ fonts.loli.net/css
+       ├─ gstatic.loli.net/s/
        │  ├─ roboto/v29/
        │  │  ├─ KFOjCnqEu92Fr1Mu51TjASc-CsTKlA.woff2
        │  │  ├─ KFOjCnqEu92Fr1Mu51TjASc0CsTKlA.woff2

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -882,7 +882,7 @@ matches the new structure:
     -      {% if font != false %}
     +      {% if config.theme.font != false %}
     +        {% set font = config.theme.font %}
-             <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+             <link href="https://gstatic.loli.net" rel="preconnect" crossorigin />
              <link
               rel="stylesheet"
     @@ -169,8 +151,12 @@
@@ -1215,8 +1215,8 @@ matches the new structure:
          {% endblock %}
          {% block fonts %}
            {% if font != false %}
-             <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
-             <link rel="stylesheet" href="https://fonts.googleapis.com/css?family={{
+             <link href="https://gstatic.loli.net" rel="preconnect" crossorigin>
+             <link rel="stylesheet" href="https://fonts.loli.net/css?family={{
                  font.text | replace(' ', '+') + ':300,400,400i,700%7C' +
                  font.code | replace(' ', '+')
                }}&display=fallback">

--- a/material/base.html
+++ b/material/base.html
@@ -58,8 +58,8 @@
       {% if config.theme.font != false %}
         {% set text = config.theme.font.text | d("Roboto", true) %}
         {% set code = config.theme.font.code | d("Roboto Mono", true) %}
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family={{
+        <link rel="preconnect" href="https://gstatic.loli.net" crossorigin>
+        <link rel="stylesheet" href="https://fonts.loli.net/css?family={{
             text | replace(' ', '+') + ':300,300i,400,400i,700,700i%7C' +
             code | replace(' ', '+') + ':400,400i,700,700i'
           }}&display=fallback">

--- a/src/base.html
+++ b/src/base.html
@@ -112,10 +112,10 @@
       {% if config.theme.font != false %}
         {% set text = config.theme.font.text | d("Roboto", true) %}
         {% set code = config.theme.font.code | d("Roboto Mono", true) %}
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link rel="preconnect" href="https://gstatic.loli.net" crossorigin />
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css?family={{
+          href="https://fonts.loli.net/css?family={{
             text | replace(' ', '+') + ':300,300i,400,400i,700,700i%7C' +
             code | replace(' ', '+') + ':400,400i,700,700i'
           }}&display=fallback"


### PR DESCRIPTION
font.googleapis.com 经常出现阻断或者无法访问的情况，大大影响访问体验，换用 fonts.loli.net gstatic.loli.net 快速且稳定。